### PR TITLE
change go version from 1.17 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/AidanJHMurphy/go-csv
 
-go 1.17
+go 1.19


### PR DESCRIPTION
In theory this should also tag the module as "version 1.0.0" but I'm not confident about that yet.